### PR TITLE
comment out LLD filters to support zabbix 2.2

### DIFF
--- a/haproxy_zbx_template.xml
+++ b/haproxy_zbx_template.xml
@@ -188,11 +188,11 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <filter>
+<!--                     <filter>
                         <evaltype>0</evaltype>
                         <formula/>
                         <conditions/>
-                    </filter>
+                    </filter> -->
                     <lifetime>5</lifetime>
                     <description/>
                     <item_prototypes>
@@ -487,11 +487,11 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <filter>
+<!--                     <filter>
                         <evaltype>0</evaltype>
                         <formula/>
                         <conditions/>
-                    </filter>
+                    </filter> -->
                     <lifetime>5</lifetime>
                     <description/>
                     <item_prototypes>
@@ -786,11 +786,11 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <filter>
+<!--                     <filter>
                         <evaltype>0</evaltype>
                         <formula/>
                         <conditions/>
-                    </filter>
+                    </filter> -->
                     <lifetime>30</lifetime>
                     <description/>
                     <item_prototypes>


### PR DESCRIPTION
Looks like zabbix 2.4 created additional keys for low level discovery, including creating more elaborate filters. Unfortunately, this means the new filter array cannot be imported into zabbix 2.2 without failing, even if the filters are not used.

https://www.zabbix.com/documentation/2.4/manual/api/reference/discoveryrule/object
vs
https://www.zabbix.com/documentation/2.2/manual/api/reference/discoveryrule/object

This patch simply comments out those unused filters, to allow import on zabbix 2.2.x
