### PR TITLE
Removed GNU specific grep parameters to work on more *NIX platforms.

### DIFF
--- a/haproxy_discovery.sh
+++ b/haproxy_discovery.sh
@@ -11,7 +11,7 @@
 #  global
 #  stats socket /run/haproxy/info.sock  mode 666 level user
 
-HAPROXY_SOCK=$(echo $1 | grep -Po "^/[^\s]+" || echo "/var/run/haproxy/info.sock")
+HAPROXY_SOCK=$(echo $1 | tr -d '\040\011\012\015' || echo "/var/run/haproxy/info.sock")
 
 get_stats() {
 	echo "show stat" | socat ${HAPROXY_SOCK} stdio 2>/dev/null | grep -v "^#"
@@ -23,7 +23,7 @@ case $1 in
 	F*) END="FRONTEND" ;;
 	S*)
 		for backend in $(get_stats | grep BACKEND | cut -d, -f1 | uniq); do
-			for server in $(get_stats | grep -P "^${backend}"',(?!BA)' | cut -d, -f2); do
+			for server in $(get_stats | grep "${backend}" | grep -v BACKEND | cut -d, -f2); do
 				serverlist="$serverlist,"'{"{#BACKEND_NAME}":"'$backend'","{#SERVER_NAME}":"'$server'"}'
 			done
 		done

--- a/haproxy_discovery.sh
+++ b/haproxy_discovery.sh
@@ -11,7 +11,8 @@
 #  global
 #  stats socket /run/haproxy/info.sock  mode 666 level user
 
-HAPROXY_SOCK=$(echo $1 | tr -d '\040\011\012\015' || echo "/var/run/haproxy/info.sock")
+HAPROXY_SOCK="/var/run/haproxy/info.sock"
+[ -n "$1" ] && echo $1 | grep -q ^/ && HAPROXY_SOCK="$(echo $1 | tr -d '\040\011\012\015')"
 
 get_stats() {
 	echo "show stat" | socat ${HAPROXY_SOCK} stdio 2>/dev/null | grep -v "^#"


### PR DESCRIPTION
Hi anapsix,

I was trying to use your template and scripts for my own purposes and stumbled across some difficulties using it on SmartOS. The reason was that my default grep was a non-GNU version and the GNU version I had was compiled without perl regexes. I diged some deeper and found a solution without using those regexes. Thanks a lot for the effort you have put into this so far. You saved me quite some time.
