### PR TITLE
Increase grep accuracy for backends in discovery scirpt

### DIFF
--- a/haproxy_discovery.sh
+++ b/haproxy_discovery.sh
@@ -40,7 +40,7 @@ case $1 in
 	F*) END="FRONTEND" ;;
 	S*)
 		for backend in $(get_stats | grep BACKEND | cut -d, -f1 | uniq); do
-			for server in $(get_stats | grep "${backend}," | grep -v BACKEND | cut -d, -f2); do
+			for server in $(get_stats | grep "^${backend}," | grep -v BACKEND | cut -d, -f2); do
 				serverlist="$serverlist,\n"'\t\t{\n\t\t\t"{#BACKEND_NAME}":"'$backend'",\n\t\t\t"{#SERVER_NAME}":"'$server'"}'
 			done
 		done


### PR DESCRIPTION
grepping for backend backend01 will match both backend01 and
mybackend01, putting erroneous checks into Zabbix. Carat added to grep
the beginning of the line sorts this out.
