### PR TITLE
fix race condition leading to spurious 'server DOWN' events

### DIFF
--- a/haproxy_stats.sh
+++ b/haproxy_stats.sh
@@ -175,7 +175,8 @@ get_stats() {
   if [ ! -e ${CACHE_STATS_FILEPATH} ]
   then
     debug "no cache file found, querying haproxy"
-    query_stats "show stat" > ${CACHE_STATS_FILEPATH}
+    query_stats "show stat" > ${CACHE_STATS_FILEPATH}.tmp
+    mv -f ${CACHE_STATS_FILEPATH}.tmp ${CACHE_STATS_FILEPATH}
   else
     debug "cache file found, results are at most ${CACHE_STATS_EXPIRATION} minutes stale.."
   fi


### PR DESCRIPTION
Tried out this integration tool on our production servers and was promptly greeted with 'server down' events. It seems Zabbix takes a bit of time before finishing writing the stats file and in the meantime there is no data for the stats script.
The Zabbix template assumes no data is the same as server down...
