### PR TITLE
fixed two cases where data was unavailable

### DIFF
--- a/haproxy_stats.sh
+++ b/haproxy_stats.sh
@@ -175,8 +175,12 @@ get_stats() {
   if [ ! -e ${CACHE_STATS_FILEPATH} ]
   then
     debug "no cache file found, querying haproxy"
-    query_stats "show stat" > ${CACHE_STATS_FILEPATH}.tmp
-    mv -f ${CACHE_STATS_FILEPATH}.tmp ${CACHE_STATS_FILEPATH}
+    _TMPFILE = ${CACHE_STATS_FILEPATH}.${RANDOM}.tmp
+    query_stats "show stat" > ${_TMPFILE}
+    if [ -f $FILE ];
+        then
+            mv -f ${_TMPFILE} ${CACHE_STATS_FILEPATH}
+        fi
   else
     debug "cache file found, results are at most ${CACHE_STATS_EXPIRATION} minutes stale.."
   fi


### PR DESCRIPTION
workarounds for
- multiple parallel zabbix agent calls clobbering the temp file
- haproxy status read sometimes fails resulting in empty cache file
