### PR TITLE
Rewrite "get_stats()" so that it relies on "flock" to control concurr…

### DIFF
--- a/haproxy_stats.sh
+++ b/haproxy_stats.sh
@@ -190,7 +190,7 @@ check_cache() {
     cache_filemtime=$(stat -c '%Y' "${cache_filepath}" 2> /dev/null)
     if [ $((cache_filemtime+60*cache_expiration)) -ge ${CUR_TIMESTAMP} ]
     then
-      debug "${cache_type} file found, results have been just updated by another process.."
+      debug "${cache_type} file found, results have just been updated by another process.."
     else
       debug "no ${cache_type} file found, querying haproxy"
       query_stats "show ${cache_type}" > "${cache_filepath}"

--- a/haproxy_stats.sh
+++ b/haproxy_stats.sh
@@ -28,6 +28,10 @@ CACHE_INFO_EXPIRATION="${CACHE_INFO_EXPIRATION:-5}" # in minutes ## unused
 GET_STATS=${GET_STATS:-1} # when you update stats cache outsise of the script
 SOCAT_BIN="$(which socat)"
 NC_BIN="$(which nc)"
+FLOCK_BIN="$(which flock)"
+FLOCK_WAIT=300
+FLOCK_SUFFIX='.lock'
+CUR_TIMESTAMP="$(date '+%s')"
 
 debug() {
   [ "${DEBUG}" -eq 1 ] && echo "DEBUG: $@" >&2 || true
@@ -35,6 +39,7 @@ debug() {
 
 debug "SOCAT_BIN        => $SOCAT_BIN"
 debug "NC_BIN           => $NC_BIN"
+debug "FLOCK_BIN           => $FLOCK_BIN"
 debug "CACHE_FILEPATH   => $CACHE_FILEPATH"
 debug "CACHE_EXPIRATION => $CACHE_EXPIRATION minutes"
 debug "HAPROXY_SOCKET   => $HAPROXY_SOCKET"
@@ -169,41 +174,50 @@ query_stats() {
     fi
 }
 
-# generate stats cache file
-get_stats() {
-  find ${CACHE_STATS_FILEPATH} -mmin +${CACHE_STATS_EXPIRATION} -delete >/dev/null 2>&1
-  if [ ! -e ${CACHE_STATS_FILEPATH} ]
+# a generic cache management function, that relies on 'flock'
+check_cache() {
+  local cache_type="${1}"
+  local cache_filepath="${2}"
+  local cache_expiration="${3}"  
+  local cache_filemtime
+  if "${FLOCK_BIN}" --shared --wait "${FLOCK_WAIT}" 200
   then
-    debug "no cache file found, querying haproxy"
-    _TMPFILE=${CACHE_STATS_FILEPATH}.${RANDOM}.tmp
-    query_stats "show stat" > ${_TMPFILE}
-    if [ -f $FILE ];
-        then
-            mv -f ${_TMPFILE} ${CACHE_STATS_FILEPATH}
-        fi
-  else
-    debug "cache file found, results are at most ${CACHE_STATS_EXPIRATION} minutes stale.."
-  fi
+    cache_filemtime=$(stat -c '%Y' "${cache_filepath}" 2> /dev/null)
+    if [ $((cache_filemtime+60*cache_expiration)) -ge ${CUR_TIMESTAMP} ]
+    then
+      debug "${cache_type} file found, results are at most ${cache_expiration} minutes stale.."
+      return 0
+    fi
+  fi 200> "${cache_filepath}${FLOCK_SUFFIX}"
+  if "${FLOCK_BIN}" --exclusive --wait "${FLOCK_WAIT}" 200
+  then
+    cache_filemtime=$(stat -c '%Y' "${cache_filepath}" 2> /dev/null)
+    if [ $((cache_filemtime+60*cache_expiration)) -ge ${CUR_TIMESTAMP} ]
+    then
+      debug "${cache_type} file found, results have been just updated by another process.."
+    else
+      debug "no ${cache_type} file found, querying haproxy"
+      query_stats "show ${cache_type}" > "${cache_filepath}"
+    fi
+  fi 200> "${cache_filepath}${FLOCK_SUFFIX}"
+}
+
+# generate stats cache file if needed
+get_stats() {
+  check_cache 'stat' "${CACHE_STATS_FILEPATH}" ${CACHE_STATS_EXPIRATION}
 }
 
 # generate info cache file
 ## unused at the moment
 get_info() {
-  find $CACHE_INFO_FILEPATH -mmin +${CACHE_INFO_EXPIRATION} -delete >/dev/null 2>&1
-  if [ ! -e $CACHE_INFO_FILEPATH ]
-  then
-    debug "no cache file found, querying haproxy"
-    echo $(query_stats "show info") > ${CACHE_INFO_FILEPATH}
-  else
-    debug "cache file found, results are at most ${CACHE_INFO_EXPIRATION} minutes stale.."
-  fi
+  check_cache 'info' "${CACHE_INFO_FILEPATH}" ${CACHE_INFO_EXPIRATION}
 }
 
 # get requested stat from cache file using INDEX offset defined in MAP
 # return default value if stat is ""
 get() {
   # $1: pxname/svname
-  local _res="$(grep $1 ${CACHE_STATS_FILEPATH})"
+  local _res="$("${FLOCK_BIN}" --shared --wait "${FLOCK_WAIT}" "${CACHE_STATS_FILEPATH}${FLOCK_SUFFIX}" grep $1 "${CACHE_STATS_FILEPATH}")"
   if [ -z "${_res}" ]
   then
     echo "ERROR: bad $pxname/$svname"


### PR DESCRIPTION
Sometimes, while monitoring a HAPROXY installation of mine, Zabbix triggers messages like this:

> Item value: grep: /var/run/zabbix/haproxy_stats.cache: No such file or directory
ERROR: bad haproxy-backend/BACKEND

> Trigger expression: {hostname.domain.com:haproxy.stats[{$HAPROXY_SOCK},haproxy-backend,BACKEND,status].iregexp("^up$",#1)}=0

I figured that the current "get_stats()" implementation may trigger a race condition if multiple backends are being monitored. For example:
1. Zabbix queries information about backend "A".
2. The "get_stats()" function on the monitored server verifies that the cache file is not too old.
3. Zabbix queries information about backend "B".
4. The "get_stats()" function on the monitored server verifies that the cache file is old and deletes it.
5. The processor context on the monitored server switches to (2)
6. The "get()" function tries to open a nonexistent file, because it was deleted by another process on step (4)
5. The processor context on the monitored server switches to (4) and the cache file is recreated.

I rewrote the "get_stats()" function so that it relies on the "[flock](https://linux.die.net/man/1/flock)" executable, from the "util-linux" package. In my implementation, "get()" obtains a shared lock before reading cached HAPROXY information and "get_stats()" obtains an exclusive lock before updating the cache.