### PR TITLE
Zabbix 2.2 can't handle last()

### DIFF
--- a/haproxy_zbx_v2_template.xml
+++ b/haproxy_zbx_v2_template.xml
@@ -8620,7 +8620,7 @@ L7STS   -&gt; layer 7 response error, for example HTTP 5xx</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{HAProxy:proc.num[haproxy].last()}&lt;1</expression>
+            <expression>{HAProxy:proc.num[haproxy].last(#1)}&lt;1</expression>
             <name>HAProxy is not running on {HOST.NAME}</name>
             <url/>
             <status>0</status>


### PR DESCRIPTION
and requires last(#1) to import.